### PR TITLE
fix::added getMultiTableDefinition method (Issue #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ lib
 .env
 
 .nvmrc
+
+.idea

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -9,7 +9,7 @@ import { generateSqlFnFromAst } from './generateSqlFnFromAst';
 import { generateReturnTypeFromAst } from './generateReturnTypeFromAst';
 import { astify } from './parser';
 import { generateParamsTypeFromAst } from './generateParamsTypeFromAst';
-import { getTableDefinition } from './getTableDefinition';
+import { getTablesDefinition } from './getTablesDefinition';
 
 export const codegen = async (nodeModulePath: string, rootPath: string) => {
   const ojotasConfig = JSON.parse(fs.readFileSync('.ojotasrc.json').toString());
@@ -41,7 +41,7 @@ export const codegen = async (nodeModulePath: string, rootPath: string) => {
     ),
   ];
 
-  const tableDefinitions = await getTableDefinition(
+  const tableDefinitions = await getTablesDefinition(
     connection,
     database,
     visitedTables,

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -9,8 +9,7 @@ import { generateSqlFnFromAst } from './generateSqlFnFromAst';
 import { generateReturnTypeFromAst } from './generateReturnTypeFromAst';
 import { astify } from './parser';
 import { generateParamsTypeFromAst } from './generateParamsTypeFromAst';
-// import { getTableDefinition } from './getTableDefinition';
-import { getMultiTableDefinition } from './getTableDefinition';
+import { getTableDefinition } from './getTableDefinition';
 
 export const codegen = async (nodeModulePath: string, rootPath: string) => {
   const ojotasConfig = JSON.parse(fs.readFileSync('.ojotasrc.json').toString());
@@ -42,20 +41,7 @@ export const codegen = async (nodeModulePath: string, rootPath: string) => {
     ),
   ];
 
-  // const tableDefinitions = Object.fromEntries(
-  //   await Promise.all(
-  //     visitedTables.map(async (table) => {
-  //       const definition = await getTableDefinition(
-  //         connection,
-  //         database,
-  //         table,
-  //       );
-  //       return [table, definition];
-  //     }),
-  //   ),
-  // );
-
-  const tableDefinitions = await getMultiTableDefinition(
+  const tableDefinitions = await getTableDefinition(
     connection,
     database,
     visitedTables,

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -9,7 +9,8 @@ import { generateSqlFnFromAst } from './generateSqlFnFromAst';
 import { generateReturnTypeFromAst } from './generateReturnTypeFromAst';
 import { astify } from './parser';
 import { generateParamsTypeFromAst } from './generateParamsTypeFromAst';
-import { getTableDefinition } from './getTableDefinition';
+// import { getTableDefinition } from './getTableDefinition';
+import { getMultiTableDefinition } from './getTableDefinition';
 
 export const codegen = async (nodeModulePath: string, rootPath: string) => {
   const ojotasConfig = JSON.parse(fs.readFileSync('.ojotasrc.json').toString());
@@ -41,17 +42,23 @@ export const codegen = async (nodeModulePath: string, rootPath: string) => {
     ),
   ];
 
-  const tableDefinitions = Object.fromEntries(
-    await Promise.all(
-      visitedTables.map(async (table) => {
-        const definition = await getTableDefinition(
-          connection,
-          database,
-          table,
-        );
-        return [table, definition];
-      }),
-    ),
+  // const tableDefinitions = Object.fromEntries(
+  //   await Promise.all(
+  //     visitedTables.map(async (table) => {
+  //       const definition = await getTableDefinition(
+  //         connection,
+  //         database,
+  //         table,
+  //       );
+  //       return [table, definition];
+  //     }),
+  //   ),
+  // );
+
+  const tableDefinitions = await getMultiTableDefinition(
+    connection,
+    database,
+    visitedTables,
   );
 
   for await (const { file, basename, ast } of readFiles) {

--- a/src/generateParamsTypeFromAst.test.ts
+++ b/src/generateParamsTypeFromAst.test.ts
@@ -3,7 +3,7 @@ import * as assert from 'node:assert';
 
 import { generateParamsTypeFromAst } from './generateParamsTypeFromAst';
 import { astify } from './parser';
-import { TableDefinition } from './getTableDefinition';
+import { TableDefinition } from './getTablesDefinition';
 
 const assertEqualIgnoreWhiteSpaces = (actual: string, expected: string) =>
   assert.equal(actual.replace(/\s+/g, ' '), expected.replace(/\s+/g, ' '));

--- a/src/generateParamsTypeFromAst.ts
+++ b/src/generateParamsTypeFromAst.ts
@@ -1,4 +1,4 @@
-import { TableDefinition } from './getTableDefinition';
+import { TableDefinition } from './getTablesDefinition';
 import { mapColumnDefinitionToType } from './mapColumnDefinitionToType';
 import { getParamsFromAst } from './getParamsFromAst';
 import { AST } from './parser';

--- a/src/generateReturnTypeFromAst.test.ts
+++ b/src/generateReturnTypeFromAst.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'node:fs';
 
 import { generateReturnTypeFromAst } from './generateReturnTypeFromAst';
 import { astify } from './parser';
-import { TableDefinition } from './getTableDefinition';
+import { TableDefinition } from './getTablesDefinition';
 
 const assertEqualIgnoreWhiteSpaces = (actual: string, expected: string) =>
   assert.equal(actual.replace(/\s+/g, ' '), expected.replace(/\s+/g, ' '));

--- a/src/generateReturnTypeFromAst.ts
+++ b/src/generateReturnTypeFromAst.ts
@@ -1,6 +1,6 @@
 import { getSelectedColumnsFromAst } from './getSelectedColumnsFromAst';
 import { mapColumnDefinitionToType } from './mapColumnDefinitionToType';
-import { TableDefinition } from './getTableDefinition';
+import { TableDefinition } from './getTablesDefinition';
 import { Relations } from './assemble';
 import { getReturnTypeName } from './getReturnTypeName';
 import { AST } from './parser';

--- a/src/getTableDefinition.ts
+++ b/src/getTableDefinition.ts
@@ -4,56 +4,26 @@ import { ColumnDefinition } from './mapColumnDefinitionToType';
 export interface TableDefinition {
   [columnName: string]: ColumnDefinition;
 }
-
-export interface MultiTableDefinition {
-  [tableName: string]: TableDefinition;
-}
-
 const getEnumNameFromColumn = (dataType: string, columnName: string): string =>
   `${dataType}_${columnName}`;
-
 export const getTableDefinition = async (
   connection: mysql.Connection,
   tableSchema: string,
-  tableName: string,
-) => {
-  const tableDefinition: TableDefinition = {};
-
-  const [tableColumns] = await connection.query<mysql.RowDataPacket[]>(
-    'SELECT column_name, data_type, is_nullable FROM information_schema.columns WHERE table_name = ? and table_schema = ?',
-    [tableName, tableSchema],
-  );
-  tableColumns.map((schemaItem) => {
-    const columnName = schemaItem.COLUMN_NAME;
-    const dataType = schemaItem.DATA_TYPE;
-    tableDefinition[columnName] = {
-      udtName: /^(enum|set)$/i.test(dataType)
-        ? getEnumNameFromColumn(dataType, columnName)
-        : dataType,
-      nullable: schemaItem.IS_NULLABLE === 'YES',
-    };
-  });
-  return tableDefinition;
-};
-
-export const getMultiTableDefinition = async (
-  connection: mysql.Connection,
-  tableSchema: string,
   tableNames: string[],
-): Promise<MultiTableDefinition> => {
-  const multiTableDefinition: MultiTableDefinition = {};
-  const placeholders = tableNames.map(() => '?').join(',');
+): Promise<Record<string, TableDefinition>> => {
+  const tableDefinition: Record<string, TableDefinition> = {};
+
   const query = `
     SELECT 
       table_name, column_name, data_type, is_nullable 
     FROM 
       information_schema.columns 
     WHERE 
-      table_name IN (${placeholders}) AND
+      table_name IN ? AND
       table_schema = ?
   `;
   const [results] = await connection.query<mysql.RowDataPacket[]>(query, [
-    ...tableNames,
+    [tableNames],
     tableSchema,
   ]);
   results.forEach((row) => {
@@ -62,17 +32,16 @@ export const getMultiTableDefinition = async (
     const dataType = row.DATA_TYPE as string;
     const isNullable = row.IS_NULLABLE as string;
 
-    if (!multiTableDefinition[tableName]) {
-      multiTableDefinition[tableName] = {};
+    if (!tableDefinition[tableName]) {
+      tableDefinition[tableName] = {};
     }
 
-    multiTableDefinition[tableName][columnName] = {
+    tableDefinition[tableName][columnName] = {
       udtName: /^(enum|set)$/i.test(dataType)
         ? getEnumNameFromColumn(dataType, columnName)
         : dataType,
       nullable: isNullable === 'YES',
     };
   });
-
-  return multiTableDefinition;
+  return tableDefinition;
 };

--- a/src/getTableDefinition.ts
+++ b/src/getTableDefinition.ts
@@ -5,6 +5,10 @@ export interface TableDefinition {
   [columnName: string]: ColumnDefinition;
 }
 
+export interface MultiTableDefinition {
+  [tableName: string]: TableDefinition;
+}
+
 const getEnumNameFromColumn = (dataType: string, columnName: string): string =>
   `${dataType}_${columnName}`;
 
@@ -30,4 +34,45 @@ export const getTableDefinition = async (
     };
   });
   return tableDefinition;
+};
+
+export const getMultiTableDefinition = async (
+  connection: mysql.Connection,
+  tableSchema: string,
+  tableNames: string[],
+): Promise<MultiTableDefinition> => {
+  const multiTableDefinition: MultiTableDefinition = {};
+  const placeholders = tableNames.map(() => '?').join(',');
+  const query = `
+    SELECT 
+      table_name, column_name, data_type, is_nullable 
+    FROM 
+      information_schema.columns 
+    WHERE 
+      table_name IN (${placeholders}) AND
+      table_schema = ?
+  `;
+  const [results] = await connection.query<mysql.RowDataPacket[]>(query, [
+    ...tableNames,
+    tableSchema,
+  ]);
+  results.forEach((row) => {
+    const tableName = row.TABLE_NAME as string;
+    const columnName = row.COLUMN_NAME as string;
+    const dataType = row.DATA_TYPE as string;
+    const isNullable = row.IS_NULLABLE as string;
+
+    if (!multiTableDefinition[tableName]) {
+      multiTableDefinition[tableName] = {};
+    }
+
+    multiTableDefinition[tableName][columnName] = {
+      udtName: /^(enum|set)$/i.test(dataType)
+        ? getEnumNameFromColumn(dataType, columnName)
+        : dataType,
+      nullable: isNullable === 'YES',
+    };
+  });
+
+  return multiTableDefinition;
 };

--- a/src/getTablesDefinition.ts
+++ b/src/getTablesDefinition.ts
@@ -6,12 +6,12 @@ export interface TableDefinition {
 }
 const getEnumNameFromColumn = (dataType: string, columnName: string): string =>
   `${dataType}_${columnName}`;
-export const getTableDefinition = async (
+export const getTablesDefinition = async (
   connection: mysql.Connection,
   tableSchema: string,
   tableNames: string[],
 ): Promise<Record<string, TableDefinition>> => {
-  const tableDefinition: Record<string, TableDefinition> = {};
+  const tablesDefinition: Record<string, TableDefinition> = {};
 
   const query = `
     SELECT 
@@ -32,16 +32,16 @@ export const getTableDefinition = async (
     const dataType = row.DATA_TYPE as string;
     const isNullable = row.IS_NULLABLE as string;
 
-    if (!tableDefinition[tableName]) {
-      tableDefinition[tableName] = {};
+    if (!tablesDefinition[tableName]) {
+      tablesDefinition[tableName] = {};
     }
 
-    tableDefinition[tableName][columnName] = {
+    tablesDefinition[tableName][columnName] = {
       udtName: /^(enum|set)$/i.test(dataType)
         ? getEnumNameFromColumn(dataType, columnName)
         : dataType,
       nullable: isNullable === 'YES',
     };
   });
-  return tableDefinition;
+  return tablesDefinition;
 };

--- a/src/getTablesDefinition.ts
+++ b/src/getTablesDefinition.ts
@@ -11,7 +11,7 @@ export const getTablesDefinition = async (
   tableSchema: string,
   tableNames: string[],
 ): Promise<Record<string, TableDefinition>> => {
-  const tablesDefinition: Record<string, TableDefinition> = {};
+  const tableDefinitions: Record<string, TableDefinition> = {};
 
   const query = `
     SELECT 
@@ -32,16 +32,16 @@ export const getTablesDefinition = async (
     const dataType = row.DATA_TYPE as string;
     const isNullable = row.IS_NULLABLE as string;
 
-    if (!tablesDefinition[tableName]) {
-      tablesDefinition[tableName] = {};
+    if (!tableDefinitions[tableName]) {
+      tableDefinitions[tableName] = {};
     }
 
-    tablesDefinition[tableName][columnName] = {
+    tableDefinitions[tableName][columnName] = {
       udtName: /^(enum|set)$/i.test(dataType)
         ? getEnumNameFromColumn(dataType, columnName)
         : dataType,
       nullable: isNullable === 'YES',
     };
   });
-  return tablesDefinition;
+  return tableDefinitions;
 };


### PR DESCRIPTION
**Context:**

- Issue https://github.com/agiletiger/ojotas/issues/23 outlines the need to do only one request to the DB to get all table definitions in codegen.ts

**Proposed Changes:**

- Implement logic to construct a single database query that retrieves all required table definitions.

**What's Included:**

- Introduction of getMultiTableDefinition: A new function that leverages the refactored getTableDefinition to fetch schema definitions for multiple tables in one go. This function is crucial for scenarios where schema information for several tables is needed simultaneously.
- Optimization in codegen.ts: The script now calls getMultiTableDefinition instead of making multiple calls to the older version of getTableDefinition. This change results in a significant reduction in database query count, especially in scenarios with numerous tables.

**Technical Details:**

- The getMultiTableDefinition function constructs a single SQL query that fetches column details (like column name, data type, and nullability) for all specified tables in a given schema.
- The results are then mapped to a structured format (MultiTableDefinition), making it easy to consume in other parts of the application.

**Usage:**

- The updated codegen.ts script will now call getMultiTableDefinition with the desired table names and schema, receiving a comprehensive map of table definitions in return. This single call replaces what would have previously been multiple calls to fetch each table's definition individually.

**update:**

- removed commented code
- set the return type of getTablesDefinition to Promise<Record<string, TableDefinition>>
- renamed the file to getTablesDefinition having a single method (remove the old one) with the same name
- put the values in the query, no need to send it in the other param as there is no safety risk
